### PR TITLE
Fixed README beman-tidy error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# beman.task: Beman Library Implementation of `task` (P3552)
+
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# beman.task: Beman Library Implementation of `task` (P3552)
 
 ![Continuous Integration Tests](https://github.com/bemanproject/task/actions/workflows/ci_tests.yml/badge.svg)
 ![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/262

Fixed README.md error, the description line wasn't the first one on the file.

Before the PR:
```
Running check [Recommendation][readme.title] ... 
[warning][readme.title]: The first line of the file 'README.md' is invalid. It should start with '# beman.task: <short_description>'.
	check [Recommendation][readme.title] ... failed
```