### PR TITLE
Modified Implements header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# beman.task: Beman Library Implementation of `task` (P3552)
+
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# beman.task: Beman Library Implementation of `task` (P3552)
 
 ![Continuous Integration Tests](https://github.com/bemanproject/task/actions/workflows/ci_tests.yml/badge.svg)
 ![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ type which becomes a `set_value_t(T)` completion signatures. The
 second template argument (`Context`) provides a way to configure
 the behavior of the coroutine. By default it can be left alone.
 
-Implements: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
+**Implements**: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
 
 ## Usage
 


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/262

Modified implements header in README, as it isnt bolded.

Before PR:
```
Running check [Recommendation][readme.implements] ... 
[warning][readme.implements]: Invalid/missing/duplicate 'Implements:' line in 'README.md'. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmeimplements for more information.
```