### PR TITLE
Added License header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# beman.task: Beman Library Implementation of `task` (P3552)
+
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# beman.task: Beman Library Implementation of `task` (P3552)
 
 ![Continuous Integration Tests](https://github.com/bemanproject/task/actions/workflows/ci_tests.yml/badge.svg)
 ![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ the behavior of the coroutine. By default it can be left alone.
 
 **Implements**: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
 
+## License
+
+`beman.task` is licensed under the Apache License v2.0 with LLVM Exceptions.
+
 ## Usage
 
 The following code snippet shows a basic use of `beman::task::task`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ type which becomes a `set_value_t(T)` completion signatures. The
 second template argument (`Context`) provides a way to configure
 the behavior of the coroutine. By default it can be left alone.
 
-Implements: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
+**Implements**: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
 
 ## Usage
 


### PR DESCRIPTION
Issue: [beman-tidy/262](https://github.com/bemanproject/beman-tidy/issues/262)

The License header was missing in README. Added it to correspond to [the standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmelicense).

Before PR:
```
Running check [Requirement][readme.license] ... 
[error][readme.license]: The file 'README.md' does not contain the required license. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmelicense for the desired format.
	check [Requirement][readme.license] ... failed
```