### PR TITLE
Add beman-tidy to pre-commit hooks (default mode)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,13 @@ repos:
         files: ^.*\.(cmake|cpp|cppm|hpp|txt|md|mds|json|js|in|yaml|yml|py|toml)$
         args: ["--write", "--ignore-words", ".codespellignore" ]
 
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.3.1
+    hooks:
+    - id: beman-tidy
+      args: [".", "--verbose"]
+
+
   # Clang-format for C++
   # This brings in a portable version of clang-format.
   # See also: https://github.com/ssciwr/clang-format-wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,6 @@ repos:
     rev: v0.3.1
     hooks:
     - id: beman-tidy
-      args: [".", "--verbose"]
-
 
   # Clang-format for C++
   # This brings in a portable version of clang-format.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# beman.task: Beman Library Implementation of `task` (P3552)
+
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# beman.task: Beman Library Implementation of `task` (P3552)
 
 ![Continuous Integration Tests](https://github.com/bemanproject/task/actions/workflows/ci_tests.yml/badge.svg)
 ![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ the behavior of the coroutine. By default it can be left alone.
 
 **Implements**: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
 
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
+
 ## License
 
 `beman.task` is licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 ![Continuous Integration Tests](https://github.com/bemanproject/task/actions/workflows/ci_tests.yml/badge.svg)
-![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
-[![Coverage](https://coveralls.io/repos/github/bemanproject/task/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/task?branch=main)
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+![Coverage](https://coveralls.io/repos/github/bemanproject/task/badge.svg?branch=main)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)
 
 `beman::execution::task<T, Context>` is a class template which
 is used as the the type of coroutine tasks. The corresponding objects

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ the behavior of the coroutine. By default it can be left alone.
 
 **Implements**: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
 
+## License
+
+`beman.task` is licensed under the Apache License v2.0 with LLVM Exceptions.
+
 ## Usage
 
 The following code snippet shows a basic use of `beman::task::task`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ type which becomes a `set_value_t(T)` completion signatures. The
 second template argument (`Context`) provides a way to configure
 the behavior of the coroutine. By default it can be left alone.
 
-Implements: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
+**Implements**: `std::execution::task` proposed in [Add a Coroutine Lazy Type (P3552)](https://wg21.link/P3552).
 
 ## Usage
 


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/262

Add beman-tidy to pre-commit hooks (default mode)