### PR TITLE
Rename tag types according to P4154

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_Declare(
     execution
     # FETCHCONTENT_SOURCE_DIR_EXECUTION ${CMAKE_SOURCE_DIR}/../execution
     GIT_REPOSITORY https://github.com/bemanproject/execution
-    GIT_TAG afde940
+    GIT_TAG 7df0f75
     SYSTEM
     FIND_PACKAGE_ARGS
         0.2.0

--- a/examples/affinity.cpp
+++ b/examples/affinity.cpp
@@ -13,7 +13,7 @@ namespace ex = beman::execution;
 
 namespace {
 struct test_receiver {
-    using receiver_concept = ex::receiver_t;
+    using receiver_concept = ex::receiver_tag;
 
     auto set_value(auto&&...) && noexcept {}
     auto set_error(auto&&) && noexcept {}

--- a/examples/async-lock.cpp
+++ b/examples/async-lock.cpp
@@ -46,12 +46,12 @@ struct queue {
 };
 
 struct request {
-    using sender_concept        = ex::sender_t;
+    using sender_concept        = ex::sender_tag;
     using completion_signatures = ex::completion_signatures<ex::set_value_t(int)>;
 
     template <typename Receiver>
     struct state : queue::notify {
-        using operation_state_concept = ex::operation_state_t;
+        using operation_state_concept = ex::operation_state_tag;
         Receiver receiver;
         int      value;
         queue&   que;

--- a/examples/demo-scope.hpp
+++ b/examples/demo-scope.hpp
@@ -28,7 +28,7 @@ class scope {
     };
 
     struct receiver {
-        using receiver_concept = ex::receiver_t;
+        using receiver_concept = ex::receiver_tag;
         scope*    self;
         job_base* state{};
 

--- a/examples/demo-tls_scheduler.hpp
+++ b/examples/demo-tls_scheduler.hpp
@@ -26,7 +26,7 @@ struct tls_domain {
 
     template <::beman::execution::receiver Rcvr, typename Data>
     struct affine_receiver {
-        using receiver_concept = ::beman::execution::receiver_t;
+        using receiver_concept = ::beman::execution::receiver_tag;
         struct env_t {
             affine_state_base<Rcvr, Data>* st;
             template <typename Q, typename... A>
@@ -51,7 +51,7 @@ struct tls_domain {
 
     template <::beman::execution::sender Sndr, ::beman::execution::scheduler Sch, ::beman::execution::receiver Rcvr>
     struct affine_state : affine_state_base<Rcvr, typename Sch::type> {
-        using operation_state_concept = ::beman::execution::operation_state_t;
+        using operation_state_concept = ::beman::execution::operation_state_tag;
         using env_t                   = decltype(::beman::execution::get_env(std::declval<Rcvr>()));
         using base_t                  = affine_state_base<Rcvr, typename Sch::type>;
         using data_t                  = typename Sch::type;
@@ -75,7 +75,7 @@ struct tls_domain {
     };
     template <::beman::execution::sender Sndr, ::beman::execution::scheduler Sch>
     struct affine_sender {
-        using sender_concept = ::beman::execution::sender_t;
+        using sender_concept = ::beman::execution::sender_tag;
 
         std::remove_cvref_t<Sndr> sndr;
         std::remove_cvref_t<Sch>  sch;
@@ -105,7 +105,7 @@ struct tls_domain {
 
 template <typename Data, ::beman::execution::scheduler Scheduler>
 struct tls_scheduler {
-    using scheduler_concept = ::beman::execution::scheduler_t;
+    using scheduler_concept = ::beman::execution::scheduler_tag;
     using type              = Data;
     struct env {
         Scheduler sched;
@@ -116,7 +116,7 @@ struct tls_scheduler {
     };
     template <::beman::execution::receiver Receiver>
     struct state {
-        using operation_state_concept = ::beman::execution::operation_state_t;
+        using operation_state_concept = ::beman::execution::operation_state_tag;
         using upstream_state_t        = decltype(::beman::execution::connect(
             ::beman::execution::schedule(std::declval<Scheduler>()), std::declval<std::remove_cvref_t<Receiver>>()));
 
@@ -128,7 +128,7 @@ struct tls_scheduler {
         auto start() & noexcept -> void { ::beman::execution::start(this->upstream); }
     };
     struct tls_sender {
-        using sender_concept = ::beman::execution::sender_t;
+        using sender_concept = ::beman::execution::sender_tag;
         using sender_type    = decltype(::beman::execution::schedule(std::declval<Scheduler>()));
 
         Scheduler sched;

--- a/examples/environment.cpp
+++ b/examples/environment.cpp
@@ -37,7 +37,7 @@ class environment {
 thread_local std::string environment::name{"<none>"};
 
 struct env_scheduler {
-    using scheduler_concept = ex::scheduler_t;
+    using scheduler_concept = ex::scheduler_tag;
 
     std::string        name;
     ex::task_scheduler scheduler;
@@ -47,7 +47,7 @@ struct env_scheduler {
 
     template <ex::receiver Rcvr>
     struct receiver {
-        using receiver_concept = ex::receiver_t;
+        using receiver_concept = ex::receiver_tag;
 
         std::remove_cvref_t<Rcvr> rcvr;
         std::string               name;
@@ -79,7 +79,7 @@ struct env_scheduler {
     };
 
     struct sender {
-        using sender_concept = ex::sender_t;
+        using sender_concept = ex::sender_tag;
         using task_sender    = decltype(ex::schedule(std::declval<ex::task_scheduler>()));
         template <typename E>
         auto get_completion_signatures(const E& e) const noexcept {

--- a/examples/into_optional.cpp
+++ b/examples/into_optional.cpp
@@ -13,7 +13,7 @@ namespace ex = beman::execution;
 namespace {
 template <typename... S>
 struct multi_sender {
-    using sender_concept        = ex::sender_t;
+    using sender_concept        = ex::sender_tag;
     using completion_signatures = ex::completion_signatures<S...>;
 
     template <typename Receiver>

--- a/examples/loop.cpp
+++ b/examples/loop.cpp
@@ -16,14 +16,14 @@ struct run_loop_env {
 
 template <ex::scheduler Scheduler>
 struct log_scheduler {
-    using scheduler_concept = ex::scheduler_t;
+    using scheduler_concept = ex::scheduler_tag;
 
     std::remove_cvref_t<Scheduler> scheduler;
 
     log_scheduler(auto&& sched) : scheduler(std::forward<decltype(sched)>(sched)) {}
 
     struct sender {
-        using sender_concept        = ex::sender_t;
+        using sender_concept        = ex::sender_tag;
         using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
         using up_sender             = decltype(ex::schedule(std::declval<Scheduler>()));
 
@@ -31,7 +31,7 @@ struct log_scheduler {
 
         template <ex::receiver Receiver>
         struct state {
-            using operation_state_concept = ex::operation_state_t;
+            using operation_state_concept = ex::operation_state_tag;
             using up_state_t              = decltype(ex::connect(std::declval<up_sender>(), std::declval<Receiver>()));
 
             up_state_t _state;

--- a/examples/rvalue-task.cpp
+++ b/examples/rvalue-task.cpp
@@ -10,7 +10,7 @@ namespace ex = beman::execution;
 
 namespace {
 struct receiver {
-    using receiver_concept = ex::receiver_t;
+    using receiver_concept = ex::receiver_tag;
     void set_value() && noexcept { std::cout << "set_value called\n"; }
     void set_error(std::exception_ptr) && noexcept { std::cout << "set_error called\n"; }
     void set_stopped() && noexcept { std::cout << "set_stopped called\n"; }

--- a/include/beman/task/detail/awaiter.hpp
+++ b/include/beman/task/detail/awaiter.hpp
@@ -15,7 +15,7 @@
 namespace beman::task::detail {
 template <typename Awaiter>
 struct awaiter_scheduler_receiver {
-    using receiver_concept = ::beman::execution::receiver_t;
+    using receiver_concept = ::beman::execution::receiver_tag;
     Awaiter* aw;
     auto     set_value(auto&&...) noexcept { this->aw->actual_complete().resume(); }
     auto     set_error(auto&&) noexcept { this->aw->actual_complete().resume(); }

--- a/include/beman/task/detail/into_optional.hpp
+++ b/include/beman/task/detail/into_optional.hpp
@@ -16,7 +16,7 @@ inline constexpr struct into_optional_t : beman::execution::sender_adaptor_closu
     template <::beman::execution::sender Upstream>
     struct sender {
         using upstream_t     = std::remove_cvref_t<Upstream>;
-        using sender_concept = ::beman::execution::sender_t;
+        using sender_concept = ::beman::execution::sender_tag;
         upstream_t upstream;
 
         template <typename...>

--- a/include/beman/task/detail/state.hpp
+++ b/include/beman/task/detail/state.hpp
@@ -17,7 +17,7 @@ namespace beman::task::detail {
 
 template <typename Task, typename T, typename C, typename Receiver>
 struct state : ::beman::task::detail::state_base<T, C>, ::beman::task::detail::state_rep<C, Receiver> {
-    using operation_state_concept = ::beman::execution::operation_state_t;
+    using operation_state_concept = ::beman::execution::operation_state_tag;
     using promise_type            = ::beman::task::detail::promise_type<Task, T, C>;
     using scheduler_type          = typename ::beman::task::detail::state_base<T, C>::scheduler_type;
     using allocator_type          = typename ::beman::task::detail::state_base<T, C>::allocator_type;

--- a/include/beman/task/detail/task.hpp
+++ b/include/beman/task/detail/task.hpp
@@ -46,7 +46,7 @@ class task {
 
   public:
     using task_concept          = int;
-    using sender_concept        = ::beman::execution::sender_t;
+    using sender_concept        = ::beman::execution::sender_tag;
     using completion_signatures = ::beman::execution::detail::meta::combine<
         ::beman::execution::completion_signatures<beman::task::detail::completion_t<Value>,
                                                   ::beman::execution::set_stopped_t()>,

--- a/include/beman/task/detail/task_scheduler.hpp
+++ b/include/beman/task/detail/task_scheduler.hpp
@@ -44,7 +44,7 @@ class task_scheduler {
     struct inner_state {
         struct receiver;
         struct receiver {
-            using receiver_concept = ::beman::execution::receiver_t;
+            using receiver_concept = ::beman::execution::receiver_tag;
             state_base* state;
             void        set_value() && noexcept { this->state->complete_value(); }
         };
@@ -70,7 +70,7 @@ class task_scheduler {
 
     template <::beman::execution::receiver Receiver>
     struct state : state_base {
-        using operation_state_concept = ::beman::execution::operation_state_t;
+        using operation_state_concept = ::beman::execution::operation_state_tag;
         std::remove_cvref_t<Receiver> receiver;
         inner_state                   s;
 
@@ -109,8 +109,8 @@ class task_scheduler {
         };
         template <::beman::execution::scheduler Scheduler>
         struct concrete : base {
-            using sender_t = decltype(::beman::execution::schedule(std::declval<Scheduler>()));
-            sender_t sender;
+            using sender_tag = decltype(::beman::execution::schedule(std::declval<Scheduler>()));
+            sender_tag sender;
 
             template <::beman::execution::scheduler S>
             concrete(S&& s) : sender(::beman::execution::schedule(std::forward<S>(s))) {}
@@ -125,7 +125,7 @@ class task_scheduler {
         poly<base, 4 * sizeof(void*)> inner_sender;
 
       public:
-        using sender_concept        = ::beman::execution::sender_t;
+        using sender_concept        = ::beman::execution::sender_tag;
         using completion_signatures = ::beman::execution::completion_signatures<::beman::execution::set_value_t()>;
         template <typename...>
         static consteval auto get_completion_signatures() noexcept -> completion_signatures {
@@ -171,7 +171,7 @@ class task_scheduler {
     poly<base, 4 * sizeof(void*)> scheduler;
 
   public:
-    using scheduler_concept = ::beman::execution::scheduler_t;
+    using scheduler_concept = ::beman::execution::scheduler_tag;
 
     template <typename S, typename Allocator = ::std::allocator<void>>
         requires(not std::same_as<task_scheduler, std::remove_cvref_t<S>>) &&

--- a/tests/beman/task/promise_base.test.cpp
+++ b/tests/beman/task/promise_base.test.cpp
@@ -21,7 +21,7 @@ namespace {
 void unexpected_call_assert(const char* message) { assert(nullptr == message); }
 
 struct void_receiver {
-    using receiver_concept = ::beman::execution::receiver_t;
+    using receiver_concept = ::beman::execution::receiver_tag;
 
     bool& flag;
     void  set_value() && noexcept { flag = true; }
@@ -31,7 +31,7 @@ struct void_receiver {
 static_assert(::beman::execution::receiver<void_receiver>);
 
 struct int_receiver {
-    using receiver_concept = ::beman::execution::receiver_t;
+    using receiver_concept = ::beman::execution::receiver_tag;
 
     int& value;
     void set_value(int v) && noexcept { this->value = v; }

--- a/tests/beman/task/promise_type.test.cpp
+++ b/tests/beman/task/promise_type.test.cpp
@@ -73,7 +73,7 @@ struct thread_pool {
     }
 
     struct scheduler {
-        using scheduler_concept = ex::scheduler_t;
+        using scheduler_concept = ex::scheduler_tag;
         struct env {
             thread_pool* pool;
 
@@ -84,7 +84,7 @@ struct thread_pool {
         };
         template <typename Receiver>
         struct state final : thread_pool::node {
-            using operation_state_concept = ex::operation_state_t;
+            using operation_state_concept = ex::operation_state_tag;
             std::remove_cvref_t<Receiver> receiver;
             thread_pool*                  pool;
 
@@ -100,7 +100,7 @@ struct thread_pool {
             void run() override { ex::set_value(std::move(this->receiver)); }
         };
         struct sender {
-            using sender_concept        = ex::sender_t;
+            using sender_concept        = ex::sender_tag;
             using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
             thread_pool* pool;
             template <typename Receiver>
@@ -167,7 +167,7 @@ struct test_task : beman::task::detail::state_base<int, environment> {
 };
 
 struct exception_receiver {
-    using receiver_concept = beman::execution::receiver_t;
+    using receiver_concept = beman::execution::receiver_tag;
     bool& flag;
 
     auto set_value(int) && noexcept { unexpected_call_assert("unexcepted set_value"); }

--- a/tests/beman/task/result_type.test.cpp
+++ b/tests/beman/task/result_type.test.cpp
@@ -17,7 +17,7 @@ namespace {
 void unexpected_call_assert(const char* msg) { assert(nullptr == msg); }
 
 struct stopped_receiver {
-    using receiver_concept = ::beman::execution::receiver_t;
+    using receiver_concept = ::beman::execution::receiver_tag;
     bool& flag;
     void  set_value(auto&&...) && noexcept { unexpected_call_assert("set_value unexpectedly called"); }
     void  set_error(auto&&) && noexcept { unexpected_call_assert("set_error unexpectedly called"); }
@@ -26,7 +26,7 @@ struct stopped_receiver {
 static_assert(::beman::execution::receiver<stopped_receiver>);
 
 struct value_receiver {
-    using receiver_concept = ::beman::execution::receiver_t;
+    using receiver_concept = ::beman::execution::receiver_tag;
     int& value;
     void set_value(int v) && noexcept { value = v; }
     void set_value(auto&&...) && noexcept { unexpected_call_assert("unexpected set_value called"); }
@@ -36,7 +36,7 @@ struct value_receiver {
 static_assert(::beman::execution::receiver<value_receiver>);
 
 struct void_receiver {
-    using receiver_concept = ::beman::execution::receiver_t;
+    using receiver_concept = ::beman::execution::receiver_tag;
     bool& flag;
     void  set_value() && noexcept { flag = true; }
     void  set_value(auto&&...) && noexcept { unexpected_call_assert("unexpected set_value called"); }
@@ -46,7 +46,7 @@ struct void_receiver {
 static_assert(::beman::execution::receiver<value_receiver>);
 
 struct error_receiver {
-    using receiver_concept = ::beman::execution::receiver_t;
+    using receiver_concept = ::beman::execution::receiver_tag;
     int& error;
     void set_value(auto&&...) && noexcept { unexpected_call_assert("unexpected set_value called"); }
     void set_error(auto&&) && noexcept { unexpected_call_assert("unexpected set_error called"); }

--- a/tests/beman/task/task_scheduler.test.cpp
+++ b/tests/beman/task/task_scheduler.test.cpp
@@ -77,7 +77,7 @@ struct thread_context {
     thread_context& operator=(const thread_context&) = delete;
 
     struct scheduler {
-        using scheduler_concept = ex::scheduler_t;
+        using scheduler_concept = ex::scheduler_tag;
         thread_context* context;
         complete        cmpl{complete::success};
         bool            operator==(const scheduler&) const = default;
@@ -92,7 +92,7 @@ struct thread_context {
                     ex::set_stopped(std::move(self->receiver));
                 }
             };
-            using operation_state_concept = ex::operation_state_t;
+            using operation_state_concept = ex::operation_state_tag;
             using token_t                 = decltype(ex::get_stop_token(ex::get_env(std::declval<Receiver>())));
             using callback_t              = ex::stop_callback_for_t<token_t, stopper>;
 
@@ -120,7 +120,7 @@ struct thread_context {
             }
         };
         struct sender {
-            using sender_concept        = ex::sender_t;
+            using sender_concept        = ex::sender_tag;
             using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
             template <typename Env>
             static consteval auto get_completion_signatures() -> completion_signatures {
@@ -165,7 +165,7 @@ stop_env(Token&&) -> stop_env<std::remove_cvref_t<Token>>;
 
 template <typename Token>
 struct stop_receiver {
-    using receiver_concept = ex::receiver_t;
+    using receiver_concept = ex::receiver_tag;
     Token        token;
     stop_result& result;
     std::latch*  completed{};


### PR DESCRIPTION
fix the deprecation warnings due to https://github.com/bemanproject/execution/pull/268