### PR TITLE
Update beman-tidy to 0.5.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         args: ["--write", "--ignore-words", ".codespellignore" ]
 
   - repo: https://github.com/bemanproject/beman-tidy
-    rev: v0.4.0
+    rev: v0.5.2
     hooks:
     - id: beman-tidy
 


### PR DESCRIPTION
## Summary

- Bump `beman-tidy` pre-commit hook to **0.5.2**
- Fix `.beman-tidy.yaml` null values (`# None` → `[]` / `[infra/]`) where present

## Test plan

- [ ] CI green
- [ ] `pre-commit run beman-tidy --all-files`